### PR TITLE
Fix study duration screen display based on screen size

### DIFF
--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -83,6 +83,10 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     alignItems: 'center',
     backgroundColor: '#FAFAFA',
     height: '90vh',
+    minHeight: '700px',
+    [theme.breakpoints.down('md')]: {
+      height: '100vh',
+    },
   },
 }))
 

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -80,7 +80,7 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     textAlign: 'center',
     backgroundColor: '#FAFAFA',
     height: '100vh',
-    paddingTop: '12vh',
+    paddingTop: theme.spacing(18.5),
   },
 }))
 

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -77,16 +77,10 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     },
   },
   introInfoContainer: {
-    display: 'flex',
-    flexDirection: 'row',
-    justifyContent: 'center',
-    alignItems: 'center',
+    textAlign: 'center',
     backgroundColor: '#FAFAFA',
-    height: '90vh',
-    minHeight: '700px',
-    [theme.breakpoints.down('md')]: {
-      height: '100vh',
-    },
+    height: '100vh',
+    paddingTop: '12vh',
   },
 }))
 

--- a/src/components/studies/scheduler/IntroInfo.tsx
+++ b/src/components/studies/scheduler/IntroInfo.tsx
@@ -25,6 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
       maxWidth: '200px',
       marginRight: '15%',
       marginLeft: theme.spacing(-1.5),
+      minWidth: '100px',
     },
     container: {
       width: '40%',

--- a/src/components/studies/scheduler/IntroInfo.tsx
+++ b/src/components/studies/scheduler/IntroInfo.tsx
@@ -25,7 +25,7 @@ const useStyles = makeStyles((theme: Theme) =>
       maxWidth: '200px',
       marginRight: '15%',
       marginLeft: theme.spacing(-1.5),
-      minWidth: '100px',
+      minWidth: '110px',
     },
     container: {
       width: '40%',

--- a/src/components/studies/scheduler/IntroInfo.tsx
+++ b/src/components/studies/scheduler/IntroInfo.tsx
@@ -21,9 +21,8 @@ const useStyles = makeStyles((theme: Theme) =>
 
       fontFamily: poppinsFont,
       fontSize: '18px',
-      fontStyle: 'normal',
       fontWeight: 600,
-      marginRight: '10%',
+      marginRight: theme.spacing(9.25),
       marginLeft: theme.spacing(-2),
       textAlign: 'left',
       width: '190px',
@@ -90,10 +89,6 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps> = ({
         isIntro={true}
         onChange={(pseudonym: StartEventId) => setstartEventId(pseudonym)}
         style={{
-          display: 'flex',
-          flexDirection: 'row',
-          justifyContent: 'space-evenly',
-          alignItems: 'center',
           width: '90%',
         }}
       />

--- a/src/components/studies/scheduler/IntroInfo.tsx
+++ b/src/components/studies/scheduler/IntroInfo.tsx
@@ -4,6 +4,7 @@ import {
   FormControlLabel,
   Theme,
   Divider,
+  Container,
 } from '@material-ui/core'
 import { makeStyles } from '@material-ui/core/styles'
 import React from 'react'
@@ -22,13 +23,12 @@ const useStyles = makeStyles((theme: Theme) =>
       fontSize: '18px',
       fontStyle: 'normal',
       fontWeight: 600,
-      maxWidth: '200px',
-      marginRight: '15%',
-      marginLeft: theme.spacing(-1.5),
-      minWidth: '110px',
+      marginRight: '10%',
+      marginLeft: theme.spacing(-2),
+      textAlign: 'left',
+      width: '190px',
     },
     container: {
-      width: '40%',
       backgroundColor: '#FAFAFA',
       display: 'flex',
       flexDirection: 'column',
@@ -67,7 +67,7 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps> = ({
   >(undefined)
 
   return (
-    <div className={classes.container}>
+    <Container maxWidth="sm" className={classes.container}>
       <FormControlLabel
         classes={{ label: classes.labelDuration }}
         label="How long will the study run for?"
@@ -107,7 +107,7 @@ const IntroInfo: React.FunctionComponent<IntroInfoProps> = ({
       >
         Continue
       </Button>
-    </div>
+    </Container>
   )
 }
 

--- a/src/components/studies/scheduler/StudyStartDate.tsx
+++ b/src/components/studies/scheduler/StudyStartDate.tsx
@@ -54,7 +54,7 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
   const options: StartEventId[] = ['activities_retrieved', 'study_start_date']
   const classes = useStyles()
   const label = isIntro ? (
-    <Box width="190px">
+    <Box maxWidth="190px">
       <strong className={classes.headerText}>
         How would you define Day 1 of your study ?
       </strong>
@@ -80,7 +80,11 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
         name="day1"
         value={startEventId}
         onChange={e => onChange(e.target.value as StartEventId)}
-        style={{ maxWidth: '60%', marginLeft: isIntro ? '10%' : '' }}
+        style={{
+          width: '190px',
+          minWidth: '190px',
+          marginLeft: isIntro ? '74px' : '',
+        }}
       >
         <FormControlLabel
           value={options[0]}

--- a/src/components/studies/scheduler/StudyStartDate.tsx
+++ b/src/components/studies/scheduler/StudyStartDate.tsx
@@ -9,6 +9,7 @@ import {
 import React from 'react'
 import { StartEventId } from '../../../types/scheduling'
 import SchedulingFormSection from './SchedulingFormSection'
+import clsx from 'clsx'
 
 export interface StudyStartDateProps {
   isIntro?: boolean
@@ -41,6 +42,14 @@ const useStyles = makeStyles(theme =>
       display: 'flex',
       flexDirection: 'row',
       alignItems: 'flex-start',
+    },
+    notInIntroRadioGroup: {
+      maxWidth: '60%',
+    },
+    inIntroRadioGroup: {
+      width: '190px',
+      minWidth: '190px',
+      marginLeft: '74px',
     },
   }),
 )
@@ -80,11 +89,10 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
         name="day1"
         value={startEventId}
         onChange={e => onChange(e.target.value as StartEventId)}
-        style={{
-          width: '190px',
-          minWidth: '190px',
-          marginLeft: isIntro ? '74px' : '',
-        }}
+        className={clsx(
+          isIntro && classes.inIntroRadioGroup,
+          !isIntro && classes.notInIntroRadioGroup,
+        )}
       >
         <FormControlLabel
           value={options[0]}

--- a/src/components/studies/scheduler/StudyStartDate.tsx
+++ b/src/components/studies/scheduler/StudyStartDate.tsx
@@ -42,10 +42,6 @@ const useStyles = makeStyles(theme =>
       flexDirection: 'row',
       alignItems: 'flex-start',
     },
-    radioGroup: {
-      maxWidth: '60%',
-      marginLeft: '10%',
-    },
   }),
 )
 
@@ -84,7 +80,7 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
         name="day1"
         value={startEventId}
         onChange={e => onChange(e.target.value as StartEventId)}
-        className={classes.radioGroup}
+        style={{ maxWidth: '60%', marginLeft: isIntro ? '10%' : '' }}
       >
         <FormControlLabel
           value={options[0]}

--- a/src/components/studies/scheduler/StudyStartDate.tsx
+++ b/src/components/studies/scheduler/StudyStartDate.tsx
@@ -42,6 +42,10 @@ const useStyles = makeStyles(theme =>
       flexDirection: 'row',
       alignItems: 'flex-start',
     },
+    radioGroup: {
+      maxWidth: '60%',
+      marginLeft: '10%',
+    },
   }),
 )
 
@@ -54,7 +58,7 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
   const options: StartEventId[] = ['activities_retrieved', 'study_start_date']
   const classes = useStyles()
   const label = isIntro ? (
-    <Box marginRight="24px" maxWidth="225px">
+    <Box width="190px">
       <strong className={classes.headerText}>
         How would you define Day 1 of your study ?
       </strong>
@@ -80,7 +84,7 @@ const StudyStartDate: React.FunctionComponent<StudyStartDateProps> = ({
         name="day1"
         value={startEventId}
         onChange={e => onChange(e.target.value as StartEventId)}
-        style={{ maxWidth: '60%' }}
+        className={classes.radioGroup}
       >
         <FormControlLabel
           value={options[0]}


### PR DESCRIPTION
The screen now looks like:

When the height is shortened:
![Screen Shot 2021-04-19 at 10 28 35 PM](https://user-images.githubusercontent.com/31671708/115342117-97c1f280-a15e-11eb-913a-ac84dd9ab86f.png)

When the width is shortened:
![Screen Shot 2021-04-19 at 10 30 54 PM](https://user-images.githubusercontent.com/31671708/115342310-ea9baa00-a15e-11eb-816c-504fbf80add8.png)

On Mobile:
![Screen Shot 2021-04-19 at 10 31 48 PM](https://user-images.githubusercontent.com/31671708/115342388-0acb6900-a15f-11eb-8c76-ab2847b557e0.png)


