### PR TITLE
Fixed Section Indicator Position Issue on Safari

### DIFF
--- a/src/components/studies/app-design/StudyPageBottomPhoneContent.tsx
+++ b/src/components/studies/app-design/StudyPageBottomPhoneContent.tsx
@@ -35,10 +35,11 @@ const useStyles = makeStyles(theme => ({
     flexDirection: 'column',
     marginBottom: theme.spacing(1.25),
     marginTop: theme.spacing(1),
+    position: 'relative',
   },
   sectionSixAndSevenIndicatorPosition: {
     position: 'absolute',
-    marginLeft: theme.spacing(-39.5),
+    right: theme.spacing(33),
   },
   container: {
     padding: theme.spacing(2, 2, 2, 2.25),

--- a/src/components/studies/app-design/StudyPageTopPhoneContent.tsx
+++ b/src/components/studies/app-design/StudyPageTopPhoneContent.tsx
@@ -12,7 +12,7 @@ const useStyles = makeStyles(theme => ({
   sectionFourIndicatorPosition: {
     position: 'absolute',
     marginLeft: theme.spacing(-7),
-    marginBottom: theme.spacing(79),
+    top: theme.spacing(2.5),
   },
   headlineStyle: {
     fontFamily: playfairDisplayFont,
@@ -41,7 +41,7 @@ const useStyles = makeStyles(theme => ({
   sectionFiveIndicatorPosition: {
     position: 'absolute',
     marginLeft: theme.spacing(-7),
-    marginTop: theme.spacing(41),
+    top: theme.spacing(63)
   },
   container: {
     padding: theme.spacing(2, 2, 2, 2.25),


### PR DESCRIPTION
The section indicators on the AppDesign page used to be in the wrong positions when the user is on Safari. Made changes to CSS so now it looks identical to chrome.