### PR TITLE
Disable Nav menu when one session has no assessments

### DIFF
--- a/src/components/studies/NavButtons.tsx
+++ b/src/components/studies/NavButtons.tsx
@@ -9,12 +9,14 @@ export interface NavButtonsProps {
   currentSection: StudySection
   id: string
   onNavigate: Function
+  disabled?: boolean
 }
 
 const NavButtons: React.FunctionComponent<NavButtonsProps> = ({
   currentSection,
   id,
   onNavigate,
+  disabled
 }: NavButtonsProps) => {
 
   const currentIndex = sectionLinks.findIndex(i => i.path === currentSection)
@@ -45,6 +47,7 @@ const NavButtons: React.FunctionComponent<NavButtonsProps> = ({
             variant="contained"
             color="primary"
             onClick={() => onNavigate(next.path)}
+            disabled={disabled || false}
           >
             {next.name} <ArrowIcon />
           </NextButton>

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -324,6 +324,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
       id={id}
       currentSection={section}
       onNavigate={(section: StudySection) => changeSection(section)}
+      disabled={!allSessionsHaveAssessments()}
     ></NavButtons>
   )
   if (builderInfo.study && !builderInfo.schedule) {

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -268,7 +268,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
   }
 
   const changeSection = async (next: StudySection) => {
-    if (section === next) {
+    if (section === next || !allSessionsHaveAssessments()) {
       return
     }
 

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { Alert } from '@material-ui/lab'
 import clsx from 'clsx'
 import _ from 'lodash'
-import React, { FunctionComponent, useEffect } from 'react'
+import React, { FunctionComponent } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { RouteComponentProps, useParams } from 'react-router-dom'
 import { useUserSessionDataState } from '../../helpers/AuthContext'
@@ -124,7 +124,6 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
     section: StudySection
   }>()
   const [section, setSection] = React.useState(_section)
-  const [allSessionsHaveAssessments, setAllSessionsHaveAssessments] = React.useState(true)
   const [error, setError] = React.useState<string[]>([])
   const [schedulerErrors, setSchedulerErrors] = React.useState<
     SchedulerErrorType[]
@@ -140,21 +139,11 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
     studyDataUpdateFn({ type: 'SET_ALL', payload: builderInfo })
   }
 
-  useEffect(() => {
+  const allSessionsHaveAssessments = () => {
     const sessions = builderInfo.schedule?.sessions
-    if(!sessions || sessions.length === 0) {
-      setAllSessionsHaveAssessments(false)
-      return
-    }
-    for(const session of sessions!) {
-      const assessments = session.assessments
-      if(!assessments || assessments.length === 0) {
-        setAllSessionsHaveAssessments(false)
-        return;
-      }
-    }
-    setAllSessionsHaveAssessments(true)
-  })
+    return !_.isEmpty(sessions) && !sessions!.find(session=>_.isEmpty(session.assessments))
+  }
+    
 
   //Sets up the data from the intro page
   const createScheduleAndNameStudy = async (
@@ -394,7 +383,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
             changeSection(section)
           }}
           id={id}
-          disabled={!allSessionsHaveAssessments}
+          disabled={!allSessionsHaveAssessments()}
         ></StudyLeftNav>
 
         <Box className={classes.mainAreaWrapper}>

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -3,7 +3,7 @@ import { makeStyles } from '@material-ui/core/styles'
 import { Alert } from '@material-ui/lab'
 import clsx from 'clsx'
 import _ from 'lodash'
-import React, { FunctionComponent } from 'react'
+import React, { FunctionComponent, useEffect } from 'react'
 import { ErrorBoundary } from 'react-error-boundary'
 import { RouteComponentProps, useParams } from 'react-router-dom'
 import { useUserSessionDataState } from '../../helpers/AuthContext'
@@ -124,6 +124,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
     section: StudySection
   }>()
   const [section, setSection] = React.useState(_section)
+  const [allSessionsHaveAssessments, setAllSessionsHaveAssessments] = React.useState(true)
   const [error, setError] = React.useState<string[]>([])
   const [schedulerErrors, setSchedulerErrors] = React.useState<
     SchedulerErrorType[]
@@ -138,6 +139,23 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
   const setData = (builderInfo: StudyInfoData) => {
     studyDataUpdateFn({ type: 'SET_ALL', payload: builderInfo })
   }
+
+  useEffect(() => {
+    const sessions = builderInfo.schedule?.sessions
+    if(!sessions || sessions.length === 0) {
+      setAllSessionsHaveAssessments(false)
+      return
+    }
+    for(const session of sessions!) {
+      const assessments = session.assessments
+      if(!assessments || assessments.length === 0) {
+        setAllSessionsHaveAssessments(false)
+        return;
+      }
+    }
+    setAllSessionsHaveAssessments(true)
+  })
+
   //Sets up the data from the intro page
   const createScheduleAndNameStudy = async (
     studyId: string,
@@ -376,6 +394,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
             changeSection(section)
           }}
           id={id}
+          disabled={!allSessionsHaveAssessments}
         ></StudyLeftNav>
 
         <Box className={classes.mainAreaWrapper}>

--- a/src/components/studies/StudyLeftNav.tsx
+++ b/src/components/studies/StudyLeftNav.tsx
@@ -5,9 +5,12 @@ import clsx from 'clsx'
 import React, { FunctionComponent } from 'react'
 import { ThemeType } from '../../style/theme'
 import SideBarListItem from '../widgets/SideBarListItem'
-import { hoverNavIcons, normalNavIcons, SECTIONS as sectionLinks, StudySection } from './sections'
-
-
+import {
+  hoverNavIcons,
+  normalNavIcons,
+  SECTIONS as sectionLinks,
+  StudySection,
+} from './sections'
 
 const drawerWidth = 212
 const useStyles = makeStyles((theme: ThemeType) => ({
@@ -78,6 +81,9 @@ const useStyles = makeStyles((theme: ThemeType) => ({
   listItemCollapsed: {
     marginLeft: theme.spacing(-0.5),
   },
+  disabledElement: {
+    opacity: 0.7,
+  },
 }))
 
 type StudyLeftNavOwnProps = {
@@ -86,6 +92,7 @@ type StudyLeftNavOwnProps = {
   open: boolean
   onToggle: Function
   onNavigate: Function
+  disabled: boolean
 }
 
 type StudyLeftNavProps = StudyLeftNavOwnProps
@@ -96,11 +103,11 @@ const StudyLeftNav: FunctionComponent<StudyLeftNavProps> = ({
   onToggle,
   onNavigate,
   currentSection = 'sessions-creator',
+  disabled,
 }) => {
   const classes = useStyles()
 
   const [currentHoveredElement, setCurrentHoveredElement] = React.useState(-1)
-
 
   function typeOfIcon(index: number, sectionPath: string) {
     if (index === currentHoveredElement || sectionPath === currentSection) {
@@ -137,7 +144,10 @@ const StudyLeftNav: FunctionComponent<StudyLeftNavProps> = ({
           {open ? <ChevronLeftIcon /> : <ChevronRightIcon />}
         </IconButton>
       </Box>
-      <ul className={classes.list}>
+      <ul
+        className={classes.list}
+        style={{ pointerEvents: disabled ? 'none' : 'all' }}
+      >
         {sectionLinks.map((sectionLink, index) => (
           <div
             onMouseOver={() => setCurrentHoveredElement(index)}
@@ -162,10 +172,23 @@ const StudyLeftNav: FunctionComponent<StudyLeftNavProps> = ({
               >
                 <img
                   src={typeOfIcon(index, sectionLink.path)[index]}
-                  className={classes.navIcon}
+                  className={clsx(
+                    classes.navIcon,
+                    disabled &&
+                      sectionLink.path !== 'session-creator' &&
+                      classes.disabledElement,
+                  )}
                   alt={sectionLink.name}
                 />
-                <span>{sectionLink.name}</span>
+                <span
+                  className={clsx(
+                    disabled &&
+                      sectionLink.path !== 'session-creator' &&
+                      classes.disabledElement,
+                  )}
+                >
+                  {sectionLink.name}
+                </span>
               </div>
             </SideBarListItem>
           </div>

--- a/src/components/studies/session-creator/SessionCreator.tsx
+++ b/src/components/studies/session-creator/SessionCreator.tsx
@@ -206,6 +206,7 @@ const SessionCreator: FunctionComponent<
                   })
                 }
                 onUpdateAssessmentList={updateAssessmentList}
+                numberOfSessions={sessions.length}
               ></SingleSessionContainer>
             </Paper>
           ))}

--- a/src/components/studies/session-creator/SingleSessionContainer.tsx
+++ b/src/components/studies/session-creator/SingleSessionContainer.tsx
@@ -102,6 +102,7 @@ type SingleSessionContainerProps = {
   onUpdateSessionName: Function
   onUpdateAssessmentList: Function
   onRemoveSession: Function
+  numberOfSessions: number
 }
 
 const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = ({
@@ -112,6 +113,7 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
   onSetActiveSession,
   onUpdateSessionName,
   onUpdateAssessmentList,
+  numberOfSessions
 }: SingleSessionContainerProps) => {
   const classes = useStyles()
   const [isEditable, setIsEditable] = React.useState(false)
@@ -156,6 +158,7 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
   const getInner = (
     studySession: StudySession,
     sessionIndex: number,
+    numberOfSessions: number
   ): JSX.Element => {
     return (
       <>
@@ -171,8 +174,8 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
               ></EditableTextbox>
             </SessionIcon>
           </Box>
-
-          <Button
+          {numberOfSessions > 1 && 
+           <Button
             variant="text"
             className={classes.btnDeleteSession}
             onClick={e => {
@@ -180,9 +183,10 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
               //onRemoveSession(studySession.guid!)
               setIsConfirmDeleteOpen(true)
             }}
-          >
-            <ClearIcon fontSize="small"></ClearIcon>
-          </Button>
+            >
+              <ClearIcon fontSize="small"></ClearIcon>
+            </Button>
+          }
           <Box fontSize="12px" textAlign="right">
             {getTotalSessionTime(studySession.assessments) || 0} min.
             <ClockIcon
@@ -264,7 +268,7 @@ const SingleSessionContainer: FunctionComponent<SingleSessionContainerProps> = (
         className={clsx(classes.root /*, studySession?.active && 'active')*/)}
         onClick={() => onSetActiveSession(studySession.guid!)}
       >
-        {getInner(studySession, sessionIndex)}
+        {getInner(studySession, sessionIndex, numberOfSessions)}
 
         <Box className={classes.actions}>
           <FormControlLabel


### PR DESCRIPTION
Looks like:
![Screen Shot 2021-06-16 at 1 58 50 PM](https://user-images.githubusercontent.com/31671708/122292586-fda2d000-ceaa-11eb-8d91-54deab8158bc.png)

Also, when there is only one session remaining, revoke ability to delete the session:
![Screen Shot 2021-06-16 at 1 59 25 PM](https://user-images.githubusercontent.com/31671708/122292658-11e6cd00-ceab-11eb-82fd-373920f59938.png)
