### PR TITLE
Changes requested by Lynn

### DIFF
--- a/src/components/studies/StudyTopNav.tsx
+++ b/src/components/studies/StudyTopNav.tsx
@@ -186,7 +186,7 @@ const StudyTopNav: FunctionComponent<StudyTopNavProps> = ({
             }}
           >
             <NavLink
-              to={'/'}
+              to={'/Studies'}
               key="home"
               className={classes.toolbarLink}
               style={{ paddingBottom: '0' }}

--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -634,7 +634,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
               />
             ))}
           </Tabs>
-          <Box marginTop="-16px">
+          <Box marginTop="-16px" bgcolor="white">
             <CollapsibleLayout
               expandedWidth={300}
               isFullWidth={true}

--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -293,7 +293,7 @@ const HelpBoxSC: FunctionComponent<{
   status: RequestStatus
 }> = ({ numRows, status }) => {
   return (
-    <Box px={3} py={2} position="relative">
+    <Box position="relative">
       {!numRows && status !== 'PENDING' && (
         <HelpBox
           topOffset={40}

--- a/src/components/widgets/AppTopNav.tsx
+++ b/src/components/widgets/AppTopNav.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Paper
+  Paper,
 } from '@material-ui/core'
 import Button from '@material-ui/core/Button'
 import { makeStyles } from '@material-ui/core/styles'
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    padding: theme.spacing(0, 3)
+    padding: theme.spacing(0, 3),
   },
 
   toolbar: {

--- a/src/components/widgets/AppTopNav.tsx
+++ b/src/components/widgets/AppTopNav.tsx
@@ -7,7 +7,7 @@ import {
   IconButton,
   Menu,
   MenuItem,
-  Paper,
+  Paper
 } from '@material-ui/core'
 import Button from '@material-ui/core/Button'
 import { makeStyles } from '@material-ui/core/styles'
@@ -33,7 +33,7 @@ const useStyles = makeStyles(theme => ({
     alignItems: 'center',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    padding: theme.spacing(0, 3),
+    padding: theme.spacing(0, 3)
   },
 
   toolbar: {


### PR DESCRIPTION
1. MTB logo now redirects back to the "My Studies" page:
![Screen Shot 2021-06-25 at 12 47 07 PM](https://user-images.githubusercontent.com/31671708/123477823-77297500-d5b3-11eb-9d8a-4a70b45681da.png)
2. Extend the white background to the left in the participant manager:
![Screen Shot 2021-06-25 at 12 47 39 PM](https://user-images.githubusercontent.com/31671708/123477872-89a3ae80-d5b3-11eb-97de-408844b46357.png)
3. Get rid of gap between participant list and study ID based on which tab is selected:
![Screen Shot 2021-06-25 at 12 48 31 PM](https://user-images.githubusercontent.com/31671708/123477958-a8a24080-d5b3-11eb-869d-f3a9f9b0d8e9.png)
