### PR TITLE
Restyle study card menu

### DIFF
--- a/src/components/studies/StudyCard.tsx
+++ b/src/components/studies/StudyCard.tsx
@@ -72,8 +72,8 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     width: '100%',
     flexDirection: 'row',
     justifyContent: 'space-between',
-    padding: theme.spacing(1.25, 1.25),
     alignItems: 'center',
+    height: '40px',
   },
   lastEditedTest: {
     fontFamily: 'Lato',
@@ -125,6 +125,15 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     '100%': {
       transform: 'scale(1)',
     },
+  },
+  menuBox: {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+    boxShadow: '-2px 1px 2px 1px rgba(0, 0, 0, 0.2)',
+    backgroundColor: 'white',
+    width: '28px',
+    height: '40px',
   },
 }))
 
@@ -212,21 +221,20 @@ const CardTop: FunctionComponent<StudyCardProps> = ({
   const classes = useStyles()
 
   return (
-    <Box
-      display="flex"
-      textAlign="left"
-      paddingTop="8px"
-      className={classes.cardTopContainer}
-    >
+    <Box display="flex" textAlign="left" className={classes.cardTopContainer}>
       {study.phase !== 'completed' ? (
         <IconButton
-          style={{ padding: '0' }}
+          style={{
+            padding: '0',
+          }}
           onClick={e => {
             cancelPropagation(e)
             onSetAnchor(e.currentTarget)
           }}
         >
-          <MoreVertIcon />
+          <Box className={classes.menuBox}>
+            <MoreVertIcon />
+          </Box>
         </IconButton>
       ) : (
         <div />

--- a/src/components/studies/StudyCard.tsx
+++ b/src/components/studies/StudyCard.tsx
@@ -130,7 +130,6 @@ const useStyles = makeStyles((theme: ThemeType) => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'center',
-    boxShadow: '-2px 1px 2px 1px rgba(0, 0, 0, 0.2)',
     backgroundColor: 'white',
     width: '28px',
     height: '40px',
@@ -208,6 +207,7 @@ const CardTop: FunctionComponent<StudyCardProps> = ({
   study,
   onSetAnchor,
   section,
+  isMenuOpen,
 }: StudyCardProps) => {
   function getStatusIcon(section: string) {
     if (section === 'LIVE') {
@@ -232,7 +232,14 @@ const CardTop: FunctionComponent<StudyCardProps> = ({
             onSetAnchor(e.currentTarget)
           }}
         >
-          <Box className={classes.menuBox}>
+          <Box
+            className={classes.menuBox}
+            style={
+              isMenuOpen
+                ? { boxShadow: '-2px 1px 4px 1px rgba(0, 0, 0, 0.2)' }
+                : {}
+            }
+          >
             <MoreVertIcon />
           </Box>
         </IconButton>
@@ -257,6 +264,7 @@ type StudyCardProps = {
   onRename?: Function
   isNewlyAddedStudy?: boolean
   section: string
+  isMenuOpen: boolean
 }
 
 const StudyCard: FunctionComponent<StudyCardProps> = ({
@@ -266,6 +274,7 @@ const StudyCard: FunctionComponent<StudyCardProps> = ({
   onRename,
   isNewlyAddedStudy,
   section,
+  isMenuOpen
 }) => {
   const classes = useStyles()
   const input = React.createRef<HTMLInputElement>()
@@ -304,6 +313,7 @@ const StudyCard: FunctionComponent<StudyCardProps> = ({
             section={section}
             study={study}
             onSetAnchor={onSetAnchor}
+            isMenuOpen={isMenuOpen}
           ></CardTop>
         </>
         <CardContent>

--- a/src/components/studies/StudyList.tsx
+++ b/src/components/studies/StudyList.tsx
@@ -5,7 +5,7 @@ import {
   Divider,
   makeStyles,
   Menu,
-  MenuItem
+  MenuItem,
 } from '@material-ui/core'
 import Link from '@material-ui/core/Link'
 import React, { FunctionComponent, useEffect } from 'react'
@@ -22,6 +22,7 @@ import ConfirmationDialog from '../widgets/ConfirmationDialog'
 import { MTBHeading } from '../widgets/Headings'
 import Loader from '../widgets/Loader'
 import StudyCard from './StudyCard'
+import { latoFont } from '../../style/theme'
 
 type StudyListOwnProps = {}
 
@@ -92,6 +93,21 @@ const useStyles = makeStyles(theme => ({
       backgroundColor: '#3A3A3A',
     },
     fontFamily: 'Lato',
+  },
+  list: {
+    fontFamily: latoFont,
+    fontSize: '14px',
+    lineHeight: '17px',
+    paddingTop: theme.spacing(0),
+    paddingBottom: theme.spacing(0),
+  },
+  paper: {
+    marginLeft: theme.spacing(3.5),
+    borderRadius: '0px',
+    '& li': {
+      padding: theme.spacing(1.25, 2, 1.25, 2),
+    },
+    boxShadow: '2px 1.5px 2px 1px rgba(0, 0, 0, 0.15)',
   },
 }))
 
@@ -197,11 +213,10 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
   const handleError = useErrorHandler()
 
   const { token } = useUserSessionDataState()
-  const [menuAnchor, setMenuAnchor] =
-    React.useState<null | {
-      study: Study
-      anchorEl: HTMLElement
-    }>(null)
+  const [menuAnchor, setMenuAnchor] = React.useState<null | {
+    study: Study
+    anchorEl: HTMLElement
+  }>(null)
   const [renameStudyId, setRenameStudyId] = React.useState('')
   const classes = useStyles()
   const handleMenuClose = () => {
@@ -216,18 +231,15 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
   const [statusFilters, setStatusFilters] = React.useState<SectionStatus[]>(
     sections.map(section => section.sectionStatus),
   )
-  const [highlightedStudyId, setHighlightedStudyId] =
-    React.useState<string | null>(null)
+  const [highlightedStudyId, setHighlightedStudyId] = React.useState<
+    string | null
+  >(null)
 
   let resetNewlyAddedStudyID: NodeJS.Timeout
 
-  const {
-    data: studies,
-    status,
-    error,
-    run,
-    setData: setStudies,
-  } = useAsync<Study[]>({
+  const { data: studies, status, error, run, setData: setStudies } = useAsync<
+    Study[]
+  >({
     status: 'PENDING',
     data: [],
   })
@@ -463,6 +475,7 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
           keepMounted
           open={Boolean(menuAnchor?.anchorEl)}
           onClose={handleMenuClose}
+          classes={{ paper: classes.paper, list: classes.list }}
         >
           <MenuItem onClick={handleMenuClose}>View</MenuItem>
           {menuAnchor?.study.phase === 'design' && (

--- a/src/components/studies/StudyList.tsx
+++ b/src/components/studies/StudyList.tsx
@@ -34,6 +34,10 @@ type StudySublistProps = {
   onAction: Function
   renameStudyId: string
   highlightedStudyId: string | null
+  menuAnchor: {
+    study: Study
+    anchorEl: HTMLElement
+  } | null
 }
 
 type StudyAction = 'DELETE' | 'ANCHOR' | 'DUPLICATE' | 'RENAME'
@@ -143,10 +147,10 @@ type StudyListProps = StudyListOwnProps & RouteComponentProps
 const StudySublist: FunctionComponent<StudySublistProps> = ({
   studies,
   status,
-
   renameStudyId,
   onAction,
   highlightedStudyId,
+  menuAnchor,
 }: StudySublistProps) => {
   const classes = useStyles()
   const item = sections.find(section => section.sectionStatus === status)!
@@ -200,6 +204,10 @@ const StudySublist: FunctionComponent<StudySublistProps> = ({
               }}
               isNewlyAddedStudy={highlightedStudyId === study.identifier}
               section={item.sectionStatus}
+              isMenuOpen={
+                menuAnchor !== null &&
+                menuAnchor.study.identifier === study.identifier
+              }
             ></StudyCard>
           </Link>
         ))}
@@ -465,6 +473,7 @@ const StudyList: FunctionComponent<StudyListProps> = () => {
                     : onAction(s, action)
                 }}
                 highlightedStudyId={highlightedStudyId}
+                menuAnchor={menuAnchor}
               />
             </Box>
           ))}

--- a/src/components/studies/StudyList.tsx
+++ b/src/components/studies/StudyList.tsx
@@ -204,10 +204,7 @@ const StudySublist: FunctionComponent<StudySublistProps> = ({
               }}
               isNewlyAddedStudy={highlightedStudyId === study.identifier}
               section={item.sectionStatus}
-              isMenuOpen={
-                menuAnchor !== null &&
-                menuAnchor.study.identifier === study.identifier
-              }
+              isMenuOpen={menuAnchor?.study?.identifier === study.identifier}
             ></StudyCard>
           </Link>
         ))}


### PR DESCRIPTION
Now looks like: 
![Screen Shot 2021-06-29 at 3 40 58 PM](https://user-images.githubusercontent.com/31671708/123876566-68fb9180-d8f0-11eb-8d72-f6e7aa264751.png)

Resolves: https://sagebionetworks.jira.com/browse/MTB-177