### PR TITLE
Clear search when tab is changed.

### DIFF
--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -419,10 +419,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
     })
   const [isAllSelected, setIsAllSelected] = React.useState(false)
 
-  const [forceSearchReset, setForceSearchReset] = React.useState(false)
-
   const handleTabChange = (event: React.ChangeEvent<{}>, newValue: any) => {
-    setForceSearchReset((prev) => !prev)
     setTab(newValue)
     setCurrentPage(1)
     setIsAllSelected(false)
@@ -818,7 +815,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
                       setIsUserSearchingForParticipant(true)
                       handleSearchParticipantRequest(isById, searchedValue)
                     }}
-                    forceSearchReset={forceSearchReset}
+                    tab={tab}
                   />
                 </Box>
                 <div

--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -419,7 +419,10 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
     })
   const [isAllSelected, setIsAllSelected] = React.useState(false)
 
+  const [forceSearchReset, setForceSearchReset] = React.useState(false)
+
   const handleTabChange = (event: React.ChangeEvent<{}>, newValue: any) => {
+    setForceSearchReset((prev) => !prev)
     setTab(newValue)
     setCurrentPage(1)
     setIsAllSelected(false)
@@ -815,6 +818,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
                       setIsUserSearchingForParticipant(true)
                       handleSearchParticipantRequest(isById, searchedValue)
                     }}
+                    forceSearchReset={forceSearchReset}
                   />
                 </Box>
                 <div

--- a/src/components/studies/participants/ParticipantSearch.tsx
+++ b/src/components/studies/participants/ParticipantSearch.tsx
@@ -1,6 +1,6 @@
 import {Button} from '@material-ui/core'
 import {makeStyles} from '@material-ui/core/styles'
-import React from 'react'
+import React, {useEffect} from 'react'
 import BlackXIcon from '../../../assets/black_x_icon.svg'
 import SearchIcon from '../../../assets/search_icon.svg'
 import WhiteSearchIcon from '../../../assets/white_search_icon.svg'
@@ -80,16 +80,20 @@ type ParticipantSearchProps = {
   onReset: Function
   onSearch: Function
   isEnrolledById?: boolean
+  forceSearchReset?: boolean
 }
 
 const ParticipantSearch: React.FunctionComponent<ParticipantSearchProps> = ({
   onReset,
   onSearch,
   isEnrolledById,
+  forceSearchReset,
 }) => {
   const classes = useStyles()
-  const [isSearchingForParticipant, setIsSearchingForParticipant] =
-    React.useState(false)
+  const [
+    isSearchingForParticipant,
+    setIsSearchingForParticipant,
+  ] = React.useState(false)
 
   // True if the user is currently trying to search for a particular particpant
   const [isSearchingUsingId, setIsSearchingUsingID] = React.useState(false)
@@ -109,6 +113,10 @@ const ParticipantSearch: React.FunctionComponent<ParticipantSearchProps> = ({
     setIsSearchingUsingID(false)
     onReset()
   }
+
+  useEffect(() => {
+    handleResetSearch()
+  }, [forceSearchReset])
 
   return isSearchingForParticipant ? (
     <div className={classes.inputRow}>

--- a/src/components/studies/participants/ParticipantSearch.tsx
+++ b/src/components/studies/participants/ParticipantSearch.tsx
@@ -5,6 +5,7 @@ import BlackXIcon from '../../../assets/black_x_icon.svg'
 import SearchIcon from '../../../assets/search_icon.svg'
 import WhiteSearchIcon from '../../../assets/white_search_icon.svg'
 import {latoFont} from '../../../style/theme'
+import {ParticipantActivityType} from '../../../types/types'
 
 const ENTER_KEY = 'Enter'
 
@@ -80,14 +81,14 @@ type ParticipantSearchProps = {
   onReset: Function
   onSearch: Function
   isEnrolledById?: boolean
-  forceSearchReset?: boolean
+  tab?: ParticipantActivityType
 }
 
 const ParticipantSearch: React.FunctionComponent<ParticipantSearchProps> = ({
   onReset,
   onSearch,
   isEnrolledById,
-  forceSearchReset,
+  tab,
 }) => {
   const classes = useStyles()
   const [
@@ -116,7 +117,7 @@ const ParticipantSearch: React.FunctionComponent<ParticipantSearchProps> = ({
 
   useEffect(() => {
     handleResetSearch()
-  }, [forceSearchReset])
+  }, [tab])
 
   return isSearchingForParticipant ? (
     <div className={classes.inputRow}>


### PR DESCRIPTION
In the participant manager, when the tab is changed the search participant component is cleared.

Resolves: #256 