### PR TITLE
Restyle test accounts tab

### DIFF
--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -746,6 +746,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
                         display="flex"
                         flexDirection="row"
                         alignItems="center">
+                        {/* This is here for now because the "Send SMS link" feature is not being included in the october release. */}
                         {false && !Utility.isSignInById(study.signInTypes) && (
                           <Button
                             aria-label="send-sms-text"

--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -746,31 +746,28 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
                         display="flex"
                         flexDirection="row"
                         alignItems="center">
-                        {tab === 'ACTIVE' &&
-                          !Utility.isSignInById(study.signInTypes) && (
-                            <Button
-                              aria-label="send-sms-text"
-                              onClick={() => {
-                                setParticipantsWithError([])
-                                setDialogState({
-                                  dialogOpenRemove: false,
-                                  dialogOpenSMS: true,
-                                })
-                              }}
-                              className={classes.sendSMSButton}
-                              disabled={
-                                selectedParticipantIds[tab].length === 0
-                              }>
-                              <img
-                                src={SMSPhoneImg}
-                                className={clsx(
-                                  selectedParticipantIds[tab].length === 0 &&
-                                    classes.disabledImage,
-                                  classes.topRowImage
-                                )}></img>
-                              Send SMS link
-                            </Button>
-                          )}
+                        {false && !Utility.isSignInById(study.signInTypes) && (
+                          <Button
+                            aria-label="send-sms-text"
+                            onClick={() => {
+                              setParticipantsWithError([])
+                              setDialogState({
+                                dialogOpenRemove: false,
+                                dialogOpenSMS: true,
+                              })
+                            }}
+                            className={classes.sendSMSButton}
+                            disabled={selectedParticipantIds[tab].length === 0}>
+                            <img
+                              src={SMSPhoneImg}
+                              className={clsx(
+                                selectedParticipantIds[tab].length === 0 &&
+                                  classes.disabledImage,
+                                classes.topRowImage
+                              )}></img>
+                            Send SMS link
+                          </Button>
+                        )}
                         {tab === 'ACTIVE' && (
                           <Button
                             aria-label="batch-edit"

--- a/src/components/studies/participants/ParticipantManager.tsx
+++ b/src/components/studies/participants/ParticipantManager.tsx
@@ -746,7 +746,7 @@ const ParticipantManager: FunctionComponent<ParticipantManagerProps> = () => {
                         display="flex"
                         flexDirection="row"
                         alignItems="center">
-                        {tab !== 'WITHDRAWN' &&
+                        {tab === 'ACTIVE' &&
                           !Utility.isSignInById(study.signInTypes) && (
                             <Button
                               aria-label="send-sms-text"

--- a/src/components/studies/participants/ParticipantTableGrid.tsx
+++ b/src/components/studies/participants/ParticipantTableGrid.tsx
@@ -411,8 +411,10 @@ function getColumns(
       c => !_.includes(['note', 'edit'], c.field)
     )
   }
-  if(gridType === "TEST") {
-    participantColumns = participantColumns.filter(el => el.headerName !== "")
+  if (gridType === 'TEST') {
+    participantColumns = participantColumns.filter(
+      el => el.headerName !== 'Phone Number'
+    )
   }
 
   if (isEnrolledById) {

--- a/src/components/studies/participants/ParticipantTableGrid.tsx
+++ b/src/components/studies/participants/ParticipantTableGrid.tsx
@@ -353,7 +353,9 @@ function getColumns(
     },
     {
       field: 'externalId',
-      headerName: isEnrolledById ? 'Participant ID' : 'Log in ID',
+      headerName: isEnrolledById
+        ? 'Participant ID'
+        : `${gridType === 'TEST' ? 'Log in' : 'Reference'} ID`,
       flex: 1,
     },
     {field: 'id', headerName: 'HealthCode', flex: 2},

--- a/src/components/studies/participants/ParticipantTableGrid.tsx
+++ b/src/components/studies/participants/ParticipantTableGrid.tsx
@@ -353,7 +353,7 @@ function getColumns(
     },
     {
       field: 'externalId',
-      headerName: isEnrolledById ? 'Participant ID' : 'Reference ID',
+      headerName: isEnrolledById ? 'Participant ID' : 'Log in ID',
       flex: 1,
     },
     {field: 'id', headerName: 'HealthCode', flex: 2},
@@ -411,6 +411,9 @@ function getColumns(
       c => !_.includes(['note', 'edit'], c.field)
     )
   }
+  if(gridType === "TEST") {
+    participantColumns = participantColumns.filter(el => el.headerName !== "")
+  }
 
   if (isEnrolledById) {
     participantColumns = _.filter(
@@ -461,16 +464,15 @@ const ParticipantTableGrid: FunctionComponent<ParticipantTableGridProps> = ({
   const {token} = useUserSessionDataState()
 
   //when we are editing the record this is where the info is stored
-  const [participantToEdit, setParticipantToEdit] =
-    React.useState<
-      | {
-          id: string
-          participant: EditableParticipantData
-          hasSignedIn: boolean
-          shouldWithdraw: boolean
-        }
-      | undefined
-    >(undefined)
+  const [participantToEdit, setParticipantToEdit] = React.useState<
+    | {
+        id: string
+        participant: EditableParticipantData
+        hasSignedIn: boolean
+        shouldWithdraw: boolean
+      }
+    | undefined
+  >(undefined)
 
   const [selectionModel, setSelectionModel] = React.useState<string[]>([
     ...selectedParticipantIds,


### PR DESCRIPTION
1. Hide send sms button
2. Rename "Participant ID" to "Log in ID" for the test participants tab
3. Remove phone number column from the Test Participants Tab

Looks like:
![Screen Shot 2021-08-12 at 3 02 42 PM](https://user-images.githubusercontent.com/31671708/129275746-7cbad172-adb6-49cc-a732-eb26c04a1f65.png)
