### PR TITLE
Remove study burst tab and also add error handling to Define Session Start page

### DIFF
--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -581,7 +581,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps> = ({
                               }
                               if (events) {
                                 const cData = newBuilderInfoObj.study.clientData
-                                cData.events = events
+                                cData.events = [...events]
                                 newBuilderInfoObj.study = {
                                   ...newBuilderInfoObj.study,
                                   clientData: cData,

--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -141,7 +141,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps & RouteComponentProps> =
       id: string
       section: StudySection
     }>()
-    console.log('builder', id, _section)
+    // console.log('builder', id, _section)
     const [section, setSection] = React.useState(_section)
     const {
       data: schedule,
@@ -391,7 +391,10 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps & RouteComponentProps> =
       //where we are currently
       switch (section) {
         case 'scheduler': {
-          saveFn = saveSchedule
+          saveFn = async () => {
+            await saveStudy(undefined)
+            return await saveSchedule(undefined)
+          }
           break
         }
         case 'session-creator': {

--- a/src/components/studies/launch/Launch.tsx
+++ b/src/components/studies/launch/Launch.tsx
@@ -144,7 +144,7 @@ const Launch: React.FunctionComponent<
   const handleReset = () => {
     setActiveStep(0)
   }
-  const isReadOnly = StudyService.isStudyClosedToEdits(studyInfo.study)
+  const isReadOnly = StudyService.isStudyClosedToEdits(study)
   if (isReadOnly) {
     return <ReadOnlyIrbDetails study={study} />
   }

--- a/src/components/studies/scheduler/Scheduler.tsx
+++ b/src/components/studies/scheduler/Scheduler.tsx
@@ -11,7 +11,7 @@ import ConfigureBurstTab from './ConfigureBurstTab'
 import ScheduleCreatorTab from './ScheduleCreatorTab'
 import SchedulerStepper from './SchedulerStepper'
 import SessionStartTab from './SessionStartTab'
-import StudyService from "@services/study.service"
+import StudyService from '@services/study.service'
 
 const useStyles = makeStyles((theme: ThemeType) => ({
   root: {

--- a/src/components/studies/scheduler/Scheduler.tsx
+++ b/src/components/studies/scheduler/Scheduler.tsx
@@ -107,7 +107,7 @@ const Scheduler: React.FunctionComponent<
             {...props}></ScheduleCreatorTab>
           <ConfigureBurstTab {...props}></ConfigureBurstTab>
         </StepContent>
-        <Box py={2} px={2} textAlign="right" bgcolor="#fff">
+        <Box py={2} px={2} textAlign="right" bgcolor="inherit">
           <>
             {activeStep === 0 ? (
               firstPrevButton

--- a/src/components/studies/scheduler/Scheduler.tsx
+++ b/src/components/studies/scheduler/Scheduler.tsx
@@ -43,7 +43,7 @@ function getSteps() {
   return [
     {label: 'Define Session Start'},
     {label: 'Create Schedule'},
-    {label: 'Configure Optional EMA/Bursts'},
+    // {label: 'Configure Optional EMA/Bursts'},
   ]
 }
 
@@ -122,7 +122,7 @@ const Scheduler: React.FunctionComponent<
             &nbsp;&nbsp;
           </>
 
-          {activeStep < 2 ? (
+          {activeStep < 1 ? (
             <NextButton
               variant="contained"
               color="primary"

--- a/src/components/studies/scheduler/SessionStartTab.tsx
+++ b/src/components/studies/scheduler/SessionStartTab.tsx
@@ -213,7 +213,7 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
                 <Box display="block">
                   <FormGroup
                     row={true}
-                    key={index}
+                    key={evt.key}
                     style={{alignItems: 'center', marginTop: '21px'}}>
                     <input
                       key={evt.key}

--- a/src/components/studies/scheduler/SessionStartTab.tsx
+++ b/src/components/studies/scheduler/SessionStartTab.tsx
@@ -53,6 +53,10 @@ const useStyles = makeStyles((theme: Theme) =>
         outline: 'none',
       },
     },
+    newEventButton: {
+      marginTop: theme.spacing(4),
+      marginLeft: theme.spacing(0),
+    },
   })
 )
 
@@ -159,7 +163,6 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
           <Box flexShrink={0} minWidth="200px" mr={2}>
             <>
               <Box className={classes.intialLoginContainer}>Initial_Login</Box>
-
               {localEventIdentifiers.map((evt, index) => (
                 <FormGroup
                   row={true}
@@ -167,7 +170,7 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
                   style={{alignItems: 'center', marginTop: '21px'}}>
                   <input
                     key={index}
-                    value={localEventIdentifiers[index]?.identifier}
+                    value={evt.identifier}
                     onChange={e => {
                       const newIdentifiers = [...localEventIdentifiers]
                       newIdentifiers[index] = {
@@ -179,7 +182,7 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
                     onBlur={updateEvent}
                     style={{
                       border: `1px solid ${getBorderColor(
-                        localEventIdentifiers[index]?.identifier,
+                        evt.identifier,
                         index
                       )}`,
                     }}
@@ -191,10 +194,7 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
                     onClick={() => deleteEvent(evt.identifier)}>
                     <DeleteIcon
                       style={{
-                        color: getBorderColor(
-                          localEventIdentifiers[index]?.identifier,
-                          index
-                        ),
+                        color: getBorderColor(evt.identifier, index),
                       }}></DeleteIcon>
                   </IconButton>
                 </FormGroup>
@@ -203,10 +203,7 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
             <BlueButton
               variant="contained"
               onClick={addEmptyEvent}
-              style={{
-                marginTop: '32px',
-                marginLeft: '0px',
-              }}>
+              className={classes.newEventButton}>
               + New Custom Event
             </BlueButton>
           </Box>

--- a/src/components/studies/scheduler/SessionStartTab.tsx
+++ b/src/components/studies/scheduler/SessionStartTab.tsx
@@ -174,7 +174,6 @@ const SessionStartTab: FunctionComponent<SessionStartTabProps> = ({
           launches, you can specify these dates for each participant in the{' '}
           <strong>Participant Manager tab.</strong>
         </p>
-
         <MTBHeadingH2>How will your session(s) start? </MTBHeadingH2>
         <p className={classes.paragraphText}>
           You can add additional calendar Events and{' '}


### PR DESCRIPTION
Looks like:
<img width="1163" alt="Screen Shot 2021-08-26 at 12 04 36 PM" src="https://user-images.githubusercontent.com/31671708/131021265-a30d8690-e875-4ec6-89b2-491c6e42c811.png">
<img width="1014" alt="Screen Shot 2021-08-26 at 12 04 55 PM" src="https://user-images.githubusercontent.com/31671708/131021296-c261bc0b-25e0-4ad0-9f46-a641d3bae763.png">

On error:
<img width="590" alt="Screen Shot 2021-08-26 at 12 05 17 PM" src="https://user-images.githubusercontent.com/31671708/131021342-9f055bca-d6ee-45c0-a530-3b2de8c62f0e.png">

Resolves #340 