### PR TITLE
Hide timezone for studies without calendar event

### DIFF
--- a/src/components/studies/participants/grid/ParticipantTableGrid.tsx
+++ b/src/components/studies/participants/grid/ParticipantTableGrid.tsx
@@ -454,6 +454,13 @@ function getColumns(
     )
   }
 
+  // if no custom event / burst -- remove time zone column
+  if (scheduleEventIds.length === 1) {
+    participantColumns = participantColumns.filter(
+      el => el.headerName != 'Time Zone'
+    )
+  }
+
   const eventInsertionIndex = participantColumns.findIndex(
     column => column.field === 'clientTimeZone'
   )


### PR DESCRIPTION
mtb-279
In participant manager, hide timezone column for studies without calendar events.