### PR TITLE
fix(appDesign): fix upload logo button to spin when cancelling upload

### DIFF
--- a/src/components/studies/app-design/AppDesign.tsx
+++ b/src/components/studies/app-design/AppDesign.tsx
@@ -695,9 +695,11 @@ const AppDesign: React.FunctionComponent<AppDesignProps> = ({
     }
 
     setIsSettingStudyLogo(true)
-    const file = event.target.files[0]
-    const previewForImage = getPreviewForImage(file)
-    setPreviewFile(previewForImage)
+    if(event.target.files[0]){
+      const file = event.target.files[0]
+      const previewForImage = getPreviewForImage(file)
+      setPreviewFile(previewForImage)
+    }
     setIsSettingStudyLogo(false)
   }
 


### PR DESCRIPTION
Fix for logo upload button on AppDesign. 
When a logo is already uploaded and user clicks upload and cancels, causes circular spinner infinitely.