### PR TITLE
Scheduler fixes

### DIFF
--- a/src/components/studies/StudyBuilder.tsx
+++ b/src/components/studies/StudyBuilder.tsx
@@ -201,6 +201,10 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps & RouteComponentProps> =
     setDisplayFeedbackBanner(true)
   }
 
+  const hideFeedback = () => {
+    setDisplayFeedbackBanner(false)
+  }
+
   return (
     <Box id="studyBuilder">
       <ErrorBoundary FallbackComponent={ErrorFallback} onError={ErrorHandler}>
@@ -289,6 +293,7 @@ const StudyBuilder: FunctionComponent<StudyBuilderProps & RouteComponentProps> =
                         <Scheduler
                           id={id}
                           onShowFeedback={showFeedback}
+                          onHideFeedback={hideFeedback}
                           isReadOnly={!StudyService.isStudyInDesign(study)}>
                           {navButtons}
                         </Scheduler>

--- a/src/components/studies/scheduler/Duration.test.tsx
+++ b/src/components/studies/scheduler/Duration.test.tsx
@@ -1,0 +1,116 @@
+import {act, cleanup, render, screen, waitForElementToBeRemoved} from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import {DWsEnum} from '@typedefs/scheduling'
+import {createWrapper} from '__test_utils/utils'
+import Duration, {DurationProps} from './Duration'
+
+afterEach(() => {
+  cleanup()
+})
+
+const durationProps: DurationProps = {
+  onChange: Function,
+  durationString: '',
+  unitData: DWsEnum,
+  unitLabel: 'unit',
+  numberLabel: 'value',
+}
+
+function setUp(durationProps: DurationProps) {
+  const user = userEvent.setup()
+  const component = render(<Duration {...durationProps} onChange={() => {}} />, {
+    wrapper: createWrapper(),
+  })
+  const value = screen.getByRole('spinbutton')
+  const unitButton = screen.getAllByRole('button')[0]
+  return {component, user, value, unitButton}
+}
+
+describe('<Duration />', () => {
+  test('should use maxDigits to restrict number of digits in value when maxDurationDays not set', async () => {
+    const {user, value} = setUp({...durationProps, durationString: 'P20D'})
+
+    expect(value).toHaveValue(20)
+
+    await act(async () => {
+      await user.clear(value)
+      await user.type(value, '123')
+    })
+    expect(value).toHaveValue(123)
+
+    await act(async () => {
+      await user.type(value, '456')
+    })
+    expect(value).toHaveValue(123)
+
+    await act(async () => {
+      await user.clear(value)
+      await user.type(value, '5678')
+    })
+    expect(value).toHaveValue(567)
+  })
+
+  test('should use maxDurationDays to restrict value entered in days', async () => {
+    const {user, value, unitButton} = setUp({...durationProps, maxDurationDays: 1825})
+
+    user.click(unitButton)
+    const dropdown = await screen.findByRole('option', {name: /days/i})
+    user.click(dropdown)
+    await waitForElementToBeRemoved(dropdown)
+
+    expect(value).toHaveValue(null)
+    expect(unitButton).toHaveTextContent('days')
+
+    await act(async () => {
+      await user.type(value, '1825')
+    })
+    expect(value).toHaveValue(1825)
+    expect(unitButton).toHaveTextContent('days')
+
+    await act(async () => {
+      await user.clear(value)
+      await user.type(value, '1826')
+    })
+    expect(value).toHaveValue(182)
+    expect(unitButton).toHaveTextContent('days')
+  })
+
+  test('should use maxDurationDays to restrict value entered in weeks', async () => {
+    const {user, value, unitButton} = setUp({...durationProps, maxDurationDays: 1825})
+
+    user.click(unitButton)
+    const dropdown = await screen.findByRole('option', {name: /weeks/i})
+    user.click(dropdown)
+    await waitForElementToBeRemoved(dropdown)
+
+    expect(value).toHaveValue(null)
+    expect(unitButton).toHaveTextContent('weeks')
+
+    await act(async () => {
+      await user.type(value, '260')
+    })
+    expect(value).toHaveValue(260)
+    expect(unitButton).toHaveTextContent('weeks')
+
+    await act(async () => {
+      await user.clear(value)
+      await user.type(value, '261')
+    })
+    expect(value).toHaveValue(26)
+    expect(unitButton).toHaveTextContent('weeks')
+  })
+
+  test('should use maxDigits to set input field width when inputWidth not set', async () => {
+    setUp({...durationProps})
+
+    const valueParent = screen.getByLabelText(/value/i)
+    expect(valueParent).toHaveAttribute('width', '7')
+  })
+
+  test('should use inputWidth to set input field width', async () => {
+    setUp({...durationProps, inputWidth: 50})
+
+    const valueParent = screen.getByLabelText(/value/i)
+    expect(valueParent).toHaveAttribute('width', '50')
+  })
+})

--- a/src/components/studies/scheduler/Duration.tsx
+++ b/src/components/studies/scheduler/Duration.tsx
@@ -27,6 +27,10 @@ export interface DurationProps {
   placeHolder?: string
   selectWidth?: number
   inputWidth?: number
+  /* maxDigits: max number of digits that can be entered for the value, sets width of input field accordingly, defaults to 3
+  ...can override max digits restriction by setting maxDurationDays
+  ...can override input field width by setting inputWidth */
+  maxDigits?: number
 }
 
 const Duration: React.FunctionComponent<DurationProps & StandardTextFieldProps> = ({
@@ -42,6 +46,7 @@ const Duration: React.FunctionComponent<DurationProps & StandardTextFieldProps> 
   placeHolder,
   selectWidth,
   inputWidth,
+  maxDigits = 3,
   isShowClear = true,
   ...props
 }: DurationProps) => {
@@ -67,9 +72,13 @@ const Duration: React.FunctionComponent<DurationProps & StandardTextFieldProps> 
     }
   }, [durationString])
 
+  const hasAppropriateNumberOfDigits = (value: number) => {
+    return `${value}`.length <= maxDigits
+  }
+
   const validate = (value: number, unit: string) => {
     if (!maxDurationDays) {
-      return true
+      return hasAppropriateNumberOfDigits(value)
     }
     const days = unit === 'W' ? value * 7 : value
     return days <= maxDurationDays
@@ -112,7 +121,8 @@ const Duration: React.FunctionComponent<DurationProps & StandardTextFieldProps> 
         onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
           changeValue(Number(e.target.value as string), unt)
         }}
-        inputWidth={inputWidth}></SmallTextBox>
+        // inputWidth is theme.spacing
+        inputWidth={inputWidth || maxDigits + 4}></SmallTextBox>
 
       <SelectWithEnum
         disabled={!!disabled}

--- a/src/components/studies/scheduler/Scheduler.tsx
+++ b/src/components/studies/scheduler/Scheduler.tsx
@@ -126,6 +126,7 @@ type SchedulerProps = {
   id: string
   isReadOnly: boolean
   onShowFeedback: Function
+  onHideFeedback: Function
 }
 
 /* default schedule is each session only has:
@@ -153,7 +154,13 @@ function isScheduleDefault(schedule: Schedule) {
   return true
 }
 
-const Scheduler: React.FunctionComponent<SchedulerProps> = ({id, children, isReadOnly, onShowFeedback}) => {
+const Scheduler: React.FunctionComponent<SchedulerProps> = ({
+  id,
+  children,
+  isReadOnly,
+  onShowFeedback,
+  onHideFeedback,
+}) => {
   const classes = useStyles()
 
   const {data: _study} = useStudy(id)
@@ -701,7 +708,12 @@ const Scheduler: React.FunctionComponent<SchedulerProps> = ({id, children, isRea
                         )}></SchedulableSingleSessionContainer>{' '}
                     </Box>
                     <StyledButtonBar>
-                      <Button variant="outlined" onClick={() => onCancelSessionUpdate()}>
+                      <Button
+                        variant="outlined"
+                        onClick={() => {
+                          onHideFeedback()
+                          onCancelSessionUpdate()
+                        }}>
                         Cancel
                       </Button>
 


### PR DESCRIPTION
- close error banner after cancelling changes to a single session schedule
- change Duration to optionally restrict to a max number of digits and set input width accordingly