### PR TITLE
Add session scheduler tests - notifications

### DIFF
--- a/src/components/studies/scheduler/NotificationTime.tsx
+++ b/src/components/studies/scheduler/NotificationTime.tsx
@@ -114,6 +114,32 @@ const NotificationTime: React.FunctionComponent<NotificationTimeProps> = ({
     }
   }, [offset, isMultiday])
 
+  // Hook to track previous value of a prop, from: https://stackoverflow.com/a/57706747
+  const usePrevious = <T extends unknown>(value: T): T | undefined => {
+    const ref = React.useRef<T>()
+    React.useEffect(() => {
+      ref.current = value
+    })
+    return ref.current
+  }
+
+  /* Re-calculate offset when windowStartTime changes. 
+  Track prevWindowStartTime so can tell when windowStartTime has actually changed, as opposed to 
+  just when the offset is updated, which updates the NotificationWindow key and treats windowStarTime as changed. 
+  See: https://stackoverflow.com/a/60979832 */
+  const prevWindowStartTime = usePrevious(windowStartTime)
+  React.useEffect(() => {
+    if (
+      isFollowUp &&
+      isMultiday &&
+      prevWindowStartTime !== undefined &&
+      windowStartTime !== undefined &&
+      prevWindowStartTime !== windowStartTime
+    ) {
+      changeMultidayOffset({days: daysForMultidayOffset, time: timeForMultidayOffset})
+    }
+  }, [windowStartTime])
+
   //--- initial notification fns ----//
   const toggleOffsetForInitialNotification = (value: string) => {
     if (value === 'false') {
@@ -223,7 +249,7 @@ const NotificationTime: React.FunctionComponent<NotificationTimeProps> = ({
           value={timeForMultidayOffset || windowStartTime}
           style={{marginLeft: 0}}
           sourceData={getDropdownTimeItems()}
-          name="from"
+          name="after"
           onChange={e =>
             changeMultidayOffset({
               days: daysForMultidayOffset,

--- a/src/components/studies/scheduler/NotificationWindow.tsx
+++ b/src/components/studies/scheduler/NotificationWindow.tsx
@@ -62,6 +62,7 @@ export interface NotificationWindowProps {
   notification: ScheduleNotification
   children: React.ReactNode
   isError: boolean
+  canDelete?: boolean
 }
 
 const NotificationWindow: React.FunctionComponent<NotificationWindowProps> = ({
@@ -72,6 +73,7 @@ const NotificationWindow: React.FunctionComponent<NotificationWindowProps> = ({
   isMultiday,
   children,
   isError,
+  canDelete,
 }: NotificationWindowProps) => {
   const updateMessage = (options: {subject?: string; message?: string}) => {
     const messages = notification.messages || []
@@ -89,13 +91,14 @@ const NotificationWindow: React.FunctionComponent<NotificationWindowProps> = ({
       <StyledSmallSectionHeader
         onClick={() => onDelete()}
         title={`${index + 1}. ${index === 0 ? 'Initial Notification' : 'Follow-up Notification'}`}
+        canDelete={canDelete}
       />
 
       <Box mx="auto" width="auto" sx={{padding: theme.spacing(3, 3, 0, 3)}}>
         <FormControl fullWidth sx={{marginBottom: theme.spacing(1)}}>
-          <SimpleTextLabel htmlFor="subject-line">Subject line: (30 character limit)</SimpleTextLabel>
+          <SimpleTextLabel htmlFor={`subject-line-${index}`}>Subject line: (30 character limit)</SimpleTextLabel>
           <SimpleTextInput
-            id="subject-line"
+            id={`subject-line-${index}`}
             variant="outlined"
             multiline={false}
             fullWidth={true}
@@ -107,8 +110,9 @@ const NotificationWindow: React.FunctionComponent<NotificationWindowProps> = ({
         </FormControl>
 
         <FormControl fullWidth sx={{marginBottom: theme.spacing(1)}}>
-          <SimpleTextLabel htmlFor="body-text">Body text: (40 character limit)</SimpleTextLabel>
+          <SimpleTextLabel htmlFor={`body-text-${index}`}>Body text: (40 character limit)</SimpleTextLabel>
           <SimpleTextInput
+            id={`body-text-${index}`}
             multiline={true}
             fullWidth={true}
             variant="outlined"

--- a/src/components/studies/scheduler/SchedulableSingleSessionContainer.tsx
+++ b/src/components/studies/scheduler/SchedulableSingleSessionContainer.tsx
@@ -217,11 +217,9 @@ const SchedulableSingleSessionContainer: FunctionComponent<SchedulableSingleSess
   }
 
   const canDeleteNotification = (notifications: ScheduleNotification[], index: number) => {
-    // follow-up notifications are always deleteable
-    if (index > 0) return true
-
     // initial notifications are only deletable if no other notifications exist
-    return index === 0 && notifications.length === 1
+    // follow-up notifications are always deleteable
+    return index > 0 || notifications.length === 1
   }
 
   return (

--- a/src/components/studies/scheduler/SchedulableSingleSessionContainer.tsx
+++ b/src/components/studies/scheduler/SchedulableSingleSessionContainer.tsx
@@ -216,6 +216,14 @@ const SchedulableSingleSessionContainer: FunctionComponent<SchedulableSingleSess
     return index + result + messageKey
   }
 
+  const canDeleteNotification = (notifications: ScheduleNotification[], index: number) => {
+    // follow-up notifications are always deleteable
+    if (index > 0) return true
+
+    // initial notifications are only deletable if no other notifications exist
+    return index === 0 && notifications.length === 1
+  }
+
   return (
     <Box sx={{backgroundColor: '#fff', flexGrow: '1', paddingBottom: 0, paddingLeft: theme.spacing(4)}} id="SSC">
       {sessionErrorState && sessionErrorState.generalErrorMessage.length > 0 && (
@@ -388,7 +396,8 @@ const SchedulableSingleSessionContainer: FunctionComponent<SchedulableSingleSess
                   onChange={(notification: ScheduleNotification) => {
                     updateNotification(notification, index)
                   }}
-                  isError={sessionErrorState?.notificationErrors.has(index + 1) || false}>
+                  isError={sessionErrorState?.notificationErrors.has(index + 1) || false}
+                  canDelete={canDeleteNotification(schedulableSession.notifications!, index)}>
                   <NotificationTime
                     notifyAt={notification.notifyAt}
                     offset={notification.offset}

--- a/src/components/studies/scheduler/SharedComponents.tsx
+++ b/src/components/studies/scheduler/SharedComponents.tsx
@@ -2,10 +2,11 @@ import DeleteIcon from '@mui/icons-material/Close'
 import {Box, IconButton, Typography} from '@mui/material'
 import {theme} from '@style/theme'
 
-export const StyledSmallSectionHeader: React.FunctionComponent<{onClick: () => void; title: string}> = ({
-  onClick,
-  title,
-}) => (
+export const StyledSmallSectionHeader: React.FunctionComponent<{
+  onClick: () => void
+  title: string
+  canDelete?: boolean
+}> = ({onClick, title, canDelete = true}) => (
   <Box
     sx={{
       position: 'relative',
@@ -14,13 +15,15 @@ export const StyledSmallSectionHeader: React.FunctionComponent<{onClick: () => v
       padding: theme.spacing(0.5, 1),
     }}>
     <Typography sx={{ontWeight: 400, fontSize: '12px', color: '#878E95'}}>{title} </Typography>
-    <IconButton
-      aria-label="delete-button"
-      style={{position: 'absolute', top: '-4px', right: '-2px'}}
-      edge="end"
-      size="small"
-      onClick={onClick}>
-      <DeleteIcon></DeleteIcon>
-    </IconButton>
+    {canDelete && (
+      <IconButton
+        aria-label="delete-button"
+        style={{position: 'absolute', top: '-4px', right: '-2px'}}
+        edge="end"
+        size="small"
+        onClick={onClick}>
+        <DeleteIcon></DeleteIcon>
+      </IconButton>
+    )}
   </Box>
 )


### PR DESCRIPTION
- don't allow initial notification to be deleted if a follow-up notification exists
- re-calculate multiday reminder offset when windowStartTime is changed
- add session scheduler tests - notifications