### PR TITLE
[DHP-1033] Only include “+ Other” response if the type is a single choice string

### DIFF
--- a/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
+++ b/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
@@ -246,18 +246,18 @@ const SelectPhoneBottomMenu: FunctionComponent<{
     return Array.from(OPTIONS.keys()).filter(optionKey => isOptionSupported(optionKey) && !isOptionAlreadyAdded(optionKey))
   }
 
-  function addMenuItems() {
+  const SpecialOptionsMenuItems: FunctionComponent = () => {
     let options = getOptions()
     return options.length === 0 ? <NoMenuItemOptions /> :
     <>
       {options.map(optionKey => (
-      <StyledMenuItem
-        key={optionKey}
-        disabled={isOptionAlreadyAdded(optionKey)}
-        onClick={() => addGenericResponse(optionKey)}>
-        {OPTIONS.get(optionKey)?.selectDisplayLabel}
-      </StyledMenuItem>
-    ))}
+        <StyledMenuItem
+          key={optionKey}
+          disabled={isOptionAlreadyAdded(optionKey)}
+          onClick={() => addGenericResponse(optionKey)}>
+          {OPTIONS.get(optionKey)?.selectDisplayLabel}
+        </StyledMenuItem>
+      ))}
     </>
   }
 
@@ -306,7 +306,7 @@ const SelectPhoneBottomMenu: FunctionComponent<{
               padding: 0,
             },
           }}>
-          {addMenuItems()}
+          <SpecialOptionsMenuItems />
         </StyledMenu>
       </SideMenu>
     </PhoneBottom>

--- a/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
+++ b/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
@@ -1,6 +1,6 @@
 import SurveyUtils from '@components/surveys/SurveyUtils'
 import MoreVertIcon from '@mui/icons-material/MoreVert'
-import {Box, Typography} from '@mui/material'
+import {Box} from '@mui/material'
 
 import AddCircleTwoToneIcon from '@mui/icons-material/AddCircleTwoTone'
 import Button from '@mui/material/Button'
@@ -246,6 +246,21 @@ const SelectPhoneBottomMenu: FunctionComponent<{
     return Array.from(OPTIONS.keys()).filter(optionKey => isOptionSupported(optionKey) && !isOptionAlreadyAdded(optionKey))
   }
 
+  function addMenuItems() {
+    let options = getOptions()
+    return options.length === 0 ? <NoMenuItemOptions /> :
+    <>
+      {options.map(optionKey => (
+      <StyledMenuItem
+        key={optionKey}
+        disabled={isOptionAlreadyAdded(optionKey)}
+        onClick={() => addGenericResponse(optionKey)}>
+        {OPTIONS.get(optionKey)?.selectDisplayLabel}
+      </StyledMenuItem>
+    ))}
+    </>
+  }
+
   return (
     <PhoneBottom>
       <Button
@@ -291,15 +306,7 @@ const SelectPhoneBottomMenu: FunctionComponent<{
               padding: 0,
             },
           }}>
-          {getOptions().map(optionKey => (
-            <StyledMenuItem
-              key={optionKey}
-              disabled={isOptionAlreadyAdded(optionKey)}
-              onClick={() => addGenericResponse(optionKey)}>
-              {OPTIONS.get(optionKey)?.selectDisplayLabel}
-            </StyledMenuItem>
-          ))}
-          {getOptions().length == 0 && <NoMenuItemOptions /> }
+          {addMenuItems()}
         </StyledMenu>
       </SideMenu>
     </PhoneBottom>

--- a/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
+++ b/src/components/surveys/survey-design/question-edit/SelectPhoneBottomMenu.tsx
@@ -299,7 +299,7 @@ const SelectPhoneBottomMenu: FunctionComponent<{
               {OPTIONS.get(optionKey)?.selectDisplayLabel}
             </StyledMenuItem>
           ))}
-          {getOptions().length == 0 ? (<NoMenuItemOptions />) : (<></>) }
+          {getOptions().length == 0 && <NoMenuItemOptions /> }
         </StyledMenu>
       </SideMenu>
     </PhoneBottom>

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
@@ -130,7 +130,7 @@ const ChoiceValueInputRow: React.FunctionComponent<{
 }
 
 function generateValue(choice: ChoiceQuestionChoice, setTo?: number) {
-  return SurveyUtils.isSpecialSelectChoice(choice) ? choice.value : setTo ?? choice.text.replaceAll(' ', '_')
+  return SurveyUtils.isSpecialSelectChoice(choice) ? choice.value : setTo ?? choice.text.replaceAll(' ', '_').replaceAll(',', '_')
 }
 
 const Select: React.FunctionComponent<{
@@ -148,12 +148,24 @@ const Select: React.FunctionComponent<{
 
     const isSwitchedToSingleSelect = !step.singleChoice && value === 'SINGLE_SELECT'
 
+    const updatedStep = {...step}
+    let choices = isSwitchedToSingleSelect
+    ? step.choices.filter(c => !SurveyUtils.isSpecialSelectChoice(c))
+    : step.choices
+    if (!isSwitchedToSingleSelect) {
+      //if changing to a multiple select -- remove 'other'
+      delete updatedStep.other
+      if (step.baseType === 'string') {
+        for (const [_i, v] of choices.entries()) {
+          v.value = generateValue(v)
+        }
+      }
+    } 
+
     onChange({
-      ...step,
+      ...updatedStep,
       singleChoice: value === 'SINGLE_SELECT',
-      choices: isSwitchedToSingleSelect
-        ? step.choices.filter(c => !SurveyUtils.isSpecialSelectChoice(c))
-        : step.choices,
+      choices: choices,
     })
   }
 

--- a/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
+++ b/src/components/surveys/survey-design/question-edit/rhs-subcontrols/Select.tsx
@@ -153,7 +153,7 @@ const Select: React.FunctionComponent<{
     ? step.choices.filter(c => !SurveyUtils.isSpecialSelectChoice(c))
     : step.choices
     if (!isSwitchedToSingleSelect) {
-      //if changing to a multiple select -- remove 'other'
+      // if changing to a multiple select -- remove 'other'
       delete updatedStep.other
       if (step.baseType === 'string') {
         for (const [_i, v] of choices.entries()) {


### PR DESCRIPTION
https://sagebionetworks.jira.com/browse/DHP-1033

There were a few bugs and UI/UX issues that I ended up adjusting along with disallowing "other" for a multiple choice question. Basically, there was no differentiation between enabled/disabled for "none of the above" and "all of the above" and that was confusing me. Also there was no explanation for why "none" and "all" weren't allowed for single choice but there was an explanation for "other" only being included for strings. The end result was to add a generic message for "hey, you've run out of special options to add to this question - nothing else applies".